### PR TITLE
V2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Guzwrap is an object-oriented wrapper around [GuzzleHttp](http://guzzlephp.org/)
 This project is founded to make sending request with Guzzle easier and enjoyable.
 
 ## Supported PHP Versions
-Guzwrap requires **>=7.4 or >=8.0**.
+Guzwrap require **PHP >= 7.4 or >= 8.0**.
 
 # Installation
 

--- a/README.md
+++ b/README.md
@@ -244,7 +244,6 @@ $promise->wait();
   
   $promise2 = Request::get('localhost:8002')
       ->query('name', 'guzwrap')
-      ->query('wraps', 'guzzlehttp')
       ->query('sleep', 1)
       ->execAsync();
   

--- a/composer.json
+++ b/composer.json
@@ -22,5 +22,9 @@
         "psr-4": {
             "Guzwrap\\Tests\\": "tests/"
         }
+    },
+    "scripts": {
+        "test": "phpunit",
+        "analyse": "phpstan analyse"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -910,16 +910,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.12.73",
+            "version": "0.12.76",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "a08c2759d132b4247b32e03066401c3232ad99b7"
+                "reference": "7aaaf9a759a29795e8f46d48041af1c1f1b23d38"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/a08c2759d132b4247b32e03066401c3232ad99b7",
-                "reference": "a08c2759d132b4247b32e03066401c3232ad99b7",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/7aaaf9a759a29795e8f46d48041af1c1f1b23d38",
+                "reference": "7aaaf9a759a29795e8f46d48041af1c1f1b23d38",
                 "shasum": ""
             },
             "require": {
@@ -950,7 +950,7 @@
             "description": "PHPStan - PHP Static Analysis Tool",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/0.12.73"
+                "source": "https://github.com/phpstan/phpstan/tree/0.12.76"
             },
             "funding": [
                 {
@@ -966,7 +966,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-07T16:26:54+00:00"
+            "time": "2021-02-13T11:47:44+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2355,7 +2355,7 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.22.0",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
@@ -2414,7 +2414,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.22.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.22.1"
             },
             "funding": [
                 {

--- a/src/RequestInterface.php
+++ b/src/RequestInterface.php
@@ -17,11 +17,12 @@ use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Promise\PromisorInterface;
+use JsonSerializable;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
 
-interface RequestInterface
+interface RequestInterface extends JsonSerializable
 {
     /**
      * Send GET request

--- a/src/Wrapper/Form.php
+++ b/src/Wrapper/Form.php
@@ -79,8 +79,7 @@ class Form
      */
     public function file($fieldName, $filePath = null): self
     {
-        $dataType = gettype($fieldName);
-        switch ($dataType) {
+        switch (gettype($fieldName)) {
             case 'object':
                 if (is_callable($fieldName)) {
                     $file = new File();

--- a/src/Wrapper/Guzzle.php
+++ b/src/Wrapper/Guzzle.php
@@ -171,7 +171,7 @@ class Guzzle implements RequestInterface
      */
     public function request(string $method, $data, array $onceData = []): Guzzle
     {
-        switch ($data) {
+        switch (true) {
             case is_callable($data):
                 $form = new Form();
                 $data($form);
@@ -758,5 +758,13 @@ class Guzzle implements RequestInterface
         $requestData = $this->prepareRequestData();
         $client = Factory::create($requestData);
         return new \GuzzleHttp\Pool($client, $values['requests']);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->getData();
     }
 }


### PR DESCRIPTION
* [Bug Fix]: Exeception(Uncaught Error: Call to undefined function ()) thrown when request methods has empty string as uri fixed.
* [New Feature]: RequestInterface now extends \JsonSerializable to help encode the Request object easily
* Other minor improvement